### PR TITLE
Allow followupplan backend inbound

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,6 +1,10 @@
 name: Build & Deploy
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    types: [ ready_for_review ]
   workflow_dispatch:
 permissions:
   actions: read

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -65,6 +65,7 @@ spec:
     inbound:
       rules:
         - application: dinesykmeldte
+        - application: followupplan-backend
         - application: oppfolgingsplan
         - application: oppfolgingsplan-frontend
           namespace: team-esyfo

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -65,6 +65,7 @@ spec:
     inbound:
       rules:
         - application: dinesykmeldte
+        - application: followupplan-backend
         - application: oppfolgingsplan
         - application: oppfolgingsplan-frontend
           namespace: team-esyfo


### PR DESCRIPTION
Planen er at followupplan-backend kan bruke endepunktet `api/v2/dinesykmeldte/{narmestelederId}` til å finne ut om det er en aktiv sykemelding på SM det skal opprettes oppfølgingsplan for. Dette endepunktet kan også brukes når vi skal undersøke om nærmeste leder har tilgang til å se en oppfølgingsplan (eks om det er 4 måneder siden siste sykemelding).

PR i followupplan-backend er under arbeid.

Endret også workflow slik at deploy til dev ikke blir trigget på hver eneste push.