### PR TITLE
Grant access to new name for followupplan-backend

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -65,7 +65,7 @@ spec:
     inbound:
       rules:
         - application: dinesykmeldte
-        - application: followupplan-backend
+        - application: syfo-oppfolgingsplan-backend
         - application: oppfolgingsplan
         - application: oppfolgingsplan-frontend
           namespace: team-esyfo

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -65,7 +65,7 @@ spec:
     inbound:
       rules:
         - application: dinesykmeldte
-        - application: followupplan-backend
+        - application: syfo-oppfolgingsplan-backend
         - application: oppfolgingsplan
         - application: oppfolgingsplan-frontend
           namespace: team-esyfo


### PR DESCRIPTION
It is change to syfo-oppfolgingsplan-backend
