### PR TITLE
chore(deps): ignore Ktor 3.5.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
     open-pull-requests-limit: 20
     ignore:
       - dependency-name: "no.nav.helse.flex:sykepengesoknad-kafka"
+      - dependency-name: "io.ktor:*"
+        versions:
+          - "3.5.x"


### PR DESCRIPTION
## Summary

- Ignore `io.ktor:*` Dependabot updates for `3.5.x`.
- Keep the existing Dependabot ignore rule for `sykepengesoknad-kafka`.

Closes #645

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `./gradlew build`