### PR TITLE
Legg til konsumeringe av team-esyfo.syfo-narmesteleder-leesah styrt via env variabler

### DIFF
--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -74,7 +74,7 @@ services:
     image: provectuslabs/kafka-ui:latest
     container_name: kafka-ui
     ports:
-      - "9000:8080" # Access Kafka-UI on http://localhost:9000
+      - "9080:8080" # Access Kafka-UI on http://localhost:9000
     environment:
       KAFKA_CLUSTERS_0_NAME: 'Local Kafka Cluster'
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker:29092'

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -98,3 +98,7 @@ spec:
       value: api://dev-fss.pdl.pdl-api/.default
     - name: SYKETILLFELLE_SCOPE
       value: api://dev-gcp.flex.flex-syketilfelle/.default
+    - name: CONSUME_TEAMSYKMELDING_NL_LEESAH_TOPIC
+      value: "true"
+    - name: CONSUME_TEAM_ESYFO_NL_LEESAH_TOPIC
+      value: "true"

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -99,6 +99,6 @@ spec:
     - name: SYKETILLFELLE_SCOPE
       value: api://dev-gcp.flex.flex-syketilfelle/.default
     - name: CONSUME_TEAMSYKMELDING_NL_LEESAH_TOPIC
-      value: "true"
+      value: "false"
     - name: CONSUME_TEAM_ESYFO_NL_LEESAH_TOPIC
       value: "true"

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -90,3 +90,7 @@ spec:
       value: api://prod-fss.pdl.pdl-api/.default
     - name: SYKETILLFELLE_SCOPE
       value: api://prod-gcp.flex.flex-syketilfelle/.default
+    - name: CONSUME_TEAMSYKMELDING_NL_LEESAH_TOPIC
+      value: "true"
+    - name: CONSUME_TEAM_ESYFO_NL_LEESAH_TOPIC
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -15,6 +15,7 @@ data class Environment(
     val clientSecret: String = getEnvVar("AZURE_APP_CLIENT_SECRET"),
     val aadAccessTokenUrl: String = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
     val narmestelederLeesahTopic: String = "teamsykmelding.syfo-narmesteleder-leesah",
+    val syfoNarmestelederLeesahTopic: String = "teams-esyfo.syfo-narmesteleder-leesah",
     val sendtSykmeldingTopic: String = "teamsykmelding.syfo-sendt-sykmelding",
     val sykepengesoknadTopic: String = "flex.sykepengesoknad",
     val hendelserTopic: String = "team-esyfo.dinesykmeldte-hendelser-v2",
@@ -24,13 +25,24 @@ data class Environment(
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
     val dbUrl: String = getEnvVar("NAIS_DATABASE_JDBC_URL"),
     val texas: TexasEnvironment = TexasEnvironment.createFromEnvVars(),
+    val consumeTeamsykmeldingNlLeesahTopic: Boolean =
+        getEnvVar(
+            "CONSUME_TEAMSYKMELDING_NL_LEESAH_TOPIC",
+            "true",
+        ).toBoolean(),
+    val consumeTeamEsyfoNlLeesahTopic: Boolean =
+        getEnvVar(
+            "CONSUME_TEAM_ESYFO_NL_LEESAH_TOPIC",
+            "false",
+        ).toBoolean(),
 ) {
     companion object {
         val authserver = getEnvVar("AUTH_SERVER", "localhost:6969")
         val dbserver = getEnvVar("DB_SERVER", "localhost:5432")
 
         @Suppress("ktlint:standard:max-line-length")
-        val dbUrl = "jdbc:postgresql://$dbserver/dinesykmeldte-backend_dev?user=username&password=password&ssl=false"
+        val dbUrl =
+            "jdbc:postgresql://$dbserver/dinesykmeldte-backend_dev?user=username&password=password&ssl=false"
 
         fun createLocal() =
             Environment(
@@ -57,3 +69,9 @@ fun getEnvVar(
     ?: defaultValue ?: throw RuntimeException("Missing required variable \"$varName\"")
 
 fun isLocalEnv(): Boolean = getEnvVar("NAIS_CLUSTER_NAME", "local") == "local"
+
+fun isProdEnv(): Boolean =
+    getEnvVar(
+        "NAIS_CLUSTER_NAME",
+        "local",
+    ) == "prod-gcp"

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -15,7 +15,7 @@ data class Environment(
     val clientSecret: String = getEnvVar("AZURE_APP_CLIENT_SECRET"),
     val aadAccessTokenUrl: String = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
     val narmestelederLeesahTopic: String = "teamsykmelding.syfo-narmesteleder-leesah",
-    val syfoNarmestelederLeesahTopic: String = "teams-esyfo.syfo-narmesteleder-leesah",
+    val syfoNarmestelederLeesahTopic: String = "team-esyfo.syfo-narmesteleder-leesah",
     val sendtSykmeldingTopic: String = "teamsykmelding.syfo-sendt-sykmelding",
     val sykepengesoknadTopic: String = "flex.sykepengesoknad",
     val hendelserTopic: String = "team-esyfo.dinesykmeldte-hendelser-v2",

--- a/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
+++ b/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
@@ -93,25 +93,25 @@ class CommonKafkaService(
             records.forEach {
                 try {
                     when (it.topic()) {
-                        environment.narmestelederLeesahTopic ->
+                        environment.narmestelederLeesahTopic -> {
                             narmestelederService.updateNl(
                                 record = it,
                                 incrementMetrics = true,
-                            ).also {
-                                log.info(
-                                    "Recieced message on ${environment.narmestelederLeesahTopic}",
-                                )
-                            }
+                            )
+                            log.info(
+                                "Recieced message on ${environment.narmestelederLeesahTopic}",
+                            )
+                        }
 
-                        environment.syfoNarmestelederLeesahTopic ->
+                        environment.syfoNarmestelederLeesahTopic -> {
                             narmestelederService.updateNl(
                                 record = it,
                                 incrementMetrics = !consumingBothLeesahTopics(),
-                            ).also {
-                                log.info(
-                                    "Recieced message on ${environment.syfoNarmestelederLeesahTopic}",
-                                )
-                            }
+                            )
+                            log.info(
+                                "Recieced message on ${environment.syfoNarmestelederLeesahTopic}",
+                            )
+                        }
 
                         environment.sendtSykmeldingTopic ->
                             sykmeldingService.handleSendtSykmeldingKafkaMessage(it)

--- a/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
+++ b/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
@@ -97,13 +97,21 @@ class CommonKafkaService(
                             narmestelederService.updateNl(
                                 record = it,
                                 incrementMetrics = true,
-                            )
+                            ).also {
+                                log.info(
+                                    "Recieced message on ${environment.narmestelederLeesahTopic}",
+                                )
+                            }
 
                         environment.syfoNarmestelederLeesahTopic ->
                             narmestelederService.updateNl(
                                 record = it,
                                 incrementMetrics = !consumingBothLeesahTopics(),
-                            )
+                            ).also {
+                                log.info(
+                                    "Recieced message on ${environment.syfoNarmestelederLeesahTopic}",
+                                )
+                            }
 
                         environment.sendtSykmeldingTopic ->
                             sykmeldingService.handleSendtSykmeldingKafkaMessage(it)

--- a/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
+++ b/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
@@ -38,15 +38,10 @@ class CommonKafkaService(
             try {
                 while (isActive) {
                     try {
-                        log.info("Starting consuming topics")
-                        kafkaConsumer.subscribe(
-                            listOf(
-                                environment.narmestelederLeesahTopic,
-                                environment.sendtSykmeldingTopic,
-                                environment.sykepengesoknadTopic,
-                                environment.hendelserTopic,
-                            ),
-                        )
+                        val topics = determineTopics()
+                        log.info("Starting consuming topics: $topics")
+
+                        kafkaConsumer.subscribe(topics)
                         start()
                     } catch (ex: WakeupException) {
                         log.info("Kafka consumer received wakeup signal, shutting down")
@@ -72,6 +67,25 @@ class CommonKafkaService(
             }
         }
 
+    private fun determineTopics(): List<String> {
+        val topics =
+            mutableListOf(
+                environment.sendtSykmeldingTopic,
+                environment.sykepengesoknadTopic,
+                environment.hendelserTopic,
+            )
+        if (environment.consumeTeamsykmeldingNlLeesahTopic) {
+            topics.add(environment.narmestelederLeesahTopic)
+        }
+        if (environment.consumeTeamEsyfoNlLeesahTopic) {
+            topics.add(environment.syfoNarmestelederLeesahTopic)
+        }
+        return topics
+    }
+
+    private fun consumingBothLeesahTopics(): Boolean =
+        environment.consumeTeamsykmeldingNlLeesahTopic && environment.consumeTeamEsyfoNlLeesahTopic
+
     private suspend fun start() {
         var processedMessages = 0
         while (applicationState.ready) {
@@ -79,9 +93,21 @@ class CommonKafkaService(
             records.forEach {
                 try {
                     when (it.topic()) {
-                        environment.narmestelederLeesahTopic -> narmestelederService.updateNl(it)
+                        environment.narmestelederLeesahTopic ->
+                            narmestelederService.updateNl(
+                                record = it,
+                                incrementMetrics = true,
+                            )
+
+                        environment.syfoNarmestelederLeesahTopic ->
+                            narmestelederService.updateNl(
+                                record = it,
+                                incrementMetrics = !consumingBothLeesahTopics(),
+                            )
+
                         environment.sendtSykmeldingTopic ->
                             sykmeldingService.handleSendtSykmeldingKafkaMessage(it)
+
                         environment.sykepengesoknadTopic -> soknadService.handleSykepengesoknad(it)
                         environment.hendelserTopic -> hendelserService.handleHendelse(it)
                         else ->

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/NarmestelederService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/NarmestelederService.kt
@@ -21,24 +21,38 @@ class NarmestelederService(
 ) {
     private val log = logger()
 
-    suspend fun updateNl(record: ConsumerRecord<String, String>) {
+    suspend fun updateNl(
+        record: ConsumerRecord<String, String>,
+        incrementMetrics: Boolean = true,
+    ) {
         try {
-            updateNl(objectMapper.readValue<NarmestelederLeesahKafkaMessage>(record.value()))
+            updateNl(
+                objectMapper.readValue<NarmestelederLeesahKafkaMessage>(record.value()),
+                incrementMetrics,
+            )
         } catch (e: Exception) {
             log.error("Noe gikk galt ved mottak av oppdatert nærmeste leder med id ${record.key()}")
             throw e
         }
     }
 
-    suspend fun updateNl(narmesteleder: NarmestelederLeesahKafkaMessage) {
+    suspend fun updateNl(
+        narmesteleder: NarmestelederLeesahKafkaMessage,
+        incrementMetrics: Boolean = true,
+    ) {
         when (narmesteleder.aktivTom) {
             null -> {
                 narmestelederDb.insertOrUpdate(narmesteleder)
-                NL_TOPIC_COUNTER.labels("ny").inc()
+                if (incrementMetrics) {
+                    NL_TOPIC_COUNTER.labels("ny").inc()
+                }
             }
+
             else -> {
                 narmestelederDb.remove(narmesteleder.narmesteLederId.toString())
-                NL_TOPIC_COUNTER.labels("avbrutt").inc()
+                if (incrementMetrics) {
+                    NL_TOPIC_COUNTER.labels("avbrutt").inc()
+                }
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/common/kafka/CommonKafkaServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/common/kafka/CommonKafkaServiceTest.kt
@@ -112,9 +112,13 @@ private fun createCommonKafkaService(
     val environment = mockk<Environment>()
     every { environment.narmestelederLeesahTopic } returns
         "teamsykmelding.syfo-narmesteleder-leesah"
+    every { environment.syfoNarmestelederLeesahTopic } returns
+        "team-esyfo.syfo-narmesteleder-leesah"
     every { environment.sendtSykmeldingTopic } returns "teamsykmelding.syfo-sendt-sykmelding"
     every { environment.sykepengesoknadTopic } returns "flex.sykepengesoknad"
     every { environment.hendelserTopic } returns "team-esyfo.dinesykmeldte-hendelser-v2"
+    every { environment.consumeTeamsykmeldingNlLeesahTopic } returns true
+    every { environment.consumeTeamEsyfoNlLeesahTopic } returns false
 
     return CommonKafkaService(
         kafkaConsumer = kafkaConsumer,


### PR DESCRIPTION
## Beskrivelse

Styrer hvilke nærmeste leder Leesah-topics `dinesykmeldte-backend` konsumerer via miljøvariabler. Dette gjør overgangen mellom gammel og ny NL Leesah-topic kontrollerbar per miljø: dev kan konsumere begge, mens prod foreløpig bare konsumerer eksisterende `teamsykmelding`-topic.

## Endringer

- `nais/nais-dev.yaml` og `nais/nais-prod.yaml`: legger til `CONSUME_TEAMSYKMELDING_NL_LEESAH_TOPIC` og `CONSUME_TEAM_ESYFO_NL_LEESAH_TOPIC` med miljøspesifikke verdier.
- `Environment.kt`: legger til `team-esyfo.syfo-narmesteleder-leesah` og env-var-styring for hvilke NL Leesah-topics som konsumeres.
- `CommonKafkaService.kt`: bygger topic-listen dynamisk, konsumerer valgte NL Leesah-topics og logger hvilken topic NL-meldinger mottas på.
- `NarmestelederService.kt`: gjør metrikkinkrementering styrbar, slik at NL-metrikker ikke dobbelttelles når begge NL-topics konsumeres samtidig.
- `docker-compose.kafka.yml`: flytter lokal Kafka UI-port fra `9000` til `9080` og fikser manglende newline.

## Issue

Ingen issue koblet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (CI `jar-app / Build` og `jar-app / Analyze` pågår)
- [x] Endringene er testet (CI `jar-app / Test` har passert)
- [x] Ingen sensitiv data eksponert (kun env-var-navn og topic-navn)
