### PR TITLE
fix(kafka): lukk consumer kontrollert ved shutdown

### DIFF
--- a/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
+++ b/src/main/kotlin/no/nav/syfo/common/kafka/CommonKafkaService.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.common.kafka
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -13,6 +14,7 @@ import no.nav.syfo.soknad.SoknadService
 import no.nav.syfo.sykmelding.SykmeldingService
 import no.nav.syfo.util.logger
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.WakeupException
 import java.time.Duration
 import java.time.Instant
 
@@ -29,28 +31,43 @@ class CommonKafkaService(
     private val logTimer = 60_000L
     private val log = logger()
 
+    fun kafkaWakeup() = kafkaConsumer.wakeup()
+
     suspend fun startConsumer() =
         coroutineScope {
-            while (isActive) {
+            try {
+                while (isActive) {
+                    try {
+                        log.info("Starting consuming topics")
+                        kafkaConsumer.subscribe(
+                            listOf(
+                                environment.narmestelederLeesahTopic,
+                                environment.sendtSykmeldingTopic,
+                                environment.sykepengesoknadTopic,
+                                environment.hendelserTopic,
+                            ),
+                        )
+                        start()
+                    } catch (ex: WakeupException) {
+                        log.info("Kafka consumer received wakeup signal, shutting down")
+                        break
+                    } catch (ex: CancellationException) {
+                        throw ex
+                    } catch (ex: Exception) {
+                        log.warn(
+                            "Error running kafka consumer, unsubscribing and waiting 10 seconds for retry",
+                            ex,
+                        )
+                        kafkaConsumer.unsubscribe()
+                        KAFKA_CONSUMER_RESTART_COUNTER.inc()
+                        delay(10_000)
+                    }
+                }
+            } finally {
                 try {
-                    log.info("Starting consuming topics")
-                    kafkaConsumer.subscribe(
-                        listOf(
-                            environment.narmestelederLeesahTopic,
-                            environment.sendtSykmeldingTopic,
-                            environment.sykepengesoknadTopic,
-                            environment.hendelserTopic,
-                        ),
-                    )
-                    start()
+                    kafkaConsumer.close(Duration.ofSeconds(3))
                 } catch (ex: Exception) {
-                    log.warn(
-                        "Error running kafka consumer, unsubscribing and waiting 10 seconds for retry",
-                        ex,
-                    )
-                    kafkaConsumer.unsubscribe()
-                    KAFKA_CONSUMER_RESTART_COUNTER.inc()
-                    delay(10_000)
+                    log.warn("Error closing kafka consumer during shutdown", ex)
                 }
             }
         }

--- a/src/main/kotlin/no/nav/syfo/plugins/KafkaConsumers.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/KafkaConsumers.kt
@@ -14,6 +14,7 @@ fun Application.configureRunningTasks(
     val commonKafkaServiceJob = launch(Dispatchers.IO) { commonKafkaService.startConsumer() }
     val deleteServiceJob = launch(Dispatchers.IO) { deleteDataService.start() }
     monitor.subscribe(ApplicationStopping) {
+        commonKafkaService.kafkaWakeup()
         commonKafkaServiceJob.cancel()
         deleteServiceJob.cancel()
     }

--- a/src/test/kotlin/no/nav/syfo/common/kafka/CommonKafkaServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/common/kafka/CommonKafkaServiceTest.kt
@@ -1,0 +1,128 @@
+package no.nav.syfo.common.kafka
+
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.Environment
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.hendelser.HendelserService
+import no.nav.syfo.narmesteleder.NarmestelederService
+import no.nav.syfo.soknad.SoknadService
+import no.nav.syfo.sykmelding.SykmeldingService
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.WakeupException
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFailsWith
+
+class CommonKafkaServiceTest :
+    FunSpec({
+        test("wakeup exception avslutter kontrollert og lukker consumer med timeout") {
+            val kafkaConsumer = mockk<KafkaConsumer<String, String>>(relaxed = true)
+            every { kafkaConsumer.poll(any<Duration>()) } throws WakeupException()
+            val commonKafkaService = createCommonKafkaService(kafkaConsumer)
+
+            runBlocking {
+                commonKafkaService.startConsumer()
+            }
+
+            verify(exactly = 1) { kafkaConsumer.close(Duration.ofSeconds(3)) }
+            verify(exactly = 0) { kafkaConsumer.close() }
+            verify(exactly = 0) { kafkaConsumer.unsubscribe() }
+        }
+
+        test("close med timeout brukes også når wakeup shutdown får close-feil") {
+            val kafkaConsumer = mockk<KafkaConsumer<String, String>>(relaxed = true)
+            every { kafkaConsumer.poll(any<Duration>()) } throws WakeupException()
+            every {
+                kafkaConsumer.close(Duration.ofSeconds(3))
+            } throws RuntimeException("close failed")
+            val commonKafkaService = createCommonKafkaService(kafkaConsumer)
+
+            runBlocking {
+                commonKafkaService.startConsumer()
+            }
+
+            verify(exactly = 1) { kafkaConsumer.close(Duration.ofSeconds(3)) }
+            verify(exactly = 0) { kafkaConsumer.close() }
+            verify(exactly = 0) { kafkaConsumer.unsubscribe() }
+        }
+
+        test("cancellation exception propageres og behandles ikke som kafka-feil") {
+            val kafkaConsumer = mockk<KafkaConsumer<String, String>>(relaxed = true)
+            every { kafkaConsumer.poll(any<Duration>()) } throws CancellationException("cancelled")
+            val commonKafkaService = createCommonKafkaService(kafkaConsumer)
+
+            assertFailsWith<CancellationException> {
+                runBlocking {
+                    commonKafkaService.startConsumer()
+                }
+            }
+
+            verify(exactly = 1) { kafkaConsumer.close(Duration.ofSeconds(3)) }
+            verify(exactly = 0) { kafkaConsumer.close() }
+            verify(exactly = 0) { kafkaConsumer.unsubscribe() }
+        }
+
+        test("reelle kafka-feil beholder retry-path med unsubscribe og retry-delay") {
+            val kafkaConsumer = mockk<KafkaConsumer<String, String>>(relaxed = true)
+            val unsubscribeLatch = CountDownLatch(1)
+            every { kafkaConsumer.poll(any<Duration>()) } throws RuntimeException("boom")
+            every { kafkaConsumer.unsubscribe() } answers { unsubscribeLatch.countDown() }
+            val commonKafkaService = createCommonKafkaService(kafkaConsumer)
+
+            runBlocking {
+                val consumerJob = launch(Dispatchers.Default) { commonKafkaService.startConsumer() }
+
+                unsubscribeLatch.await(1, TimeUnit.SECONDS) shouldBeEqualTo true
+                delay(100)
+                consumerJob.cancel()
+                consumerJob.join()
+            }
+
+            verify(exactly = 1) { kafkaConsumer.subscribe(any<Collection<String>>()) }
+            verify(exactly = 1) { kafkaConsumer.poll(Duration.ofSeconds(10)) }
+            verify(exactly = 1) { kafkaConsumer.unsubscribe() }
+            verify(exactly = 1) { kafkaConsumer.close(Duration.ofSeconds(3)) }
+            verify(exactly = 0) { kafkaConsumer.close() }
+        }
+
+        test("kafkaWakeup delegere til underliggende consumer") {
+            val kafkaConsumer = mockk<KafkaConsumer<String, String>>(relaxed = true)
+            val commonKafkaService = createCommonKafkaService(kafkaConsumer)
+
+            commonKafkaService.kafkaWakeup()
+
+            verify(exactly = 1) { kafkaConsumer.wakeup() }
+        }
+    })
+
+private fun createCommonKafkaService(
+    kafkaConsumer: KafkaConsumer<String, String>,
+    applicationState: ApplicationState = ApplicationState(),
+): CommonKafkaService {
+    val environment = mockk<Environment>()
+    every { environment.narmestelederLeesahTopic } returns
+        "teamsykmelding.syfo-narmesteleder-leesah"
+    every { environment.sendtSykmeldingTopic } returns "teamsykmelding.syfo-sendt-sykmelding"
+    every { environment.sykepengesoknadTopic } returns "flex.sykepengesoknad"
+    every { environment.hendelserTopic } returns "team-esyfo.dinesykmeldte-hendelser-v2"
+
+    return CommonKafkaService(
+        kafkaConsumer = kafkaConsumer,
+        applicationState = applicationState,
+        environment = environment,
+        narmestelederService = mockk<NarmestelederService>(relaxed = true),
+        sykmeldingService = mockk<SykmeldingService>(relaxed = true),
+        soknadService = mockk<SoknadService>(relaxed = true),
+        hendelserService = mockk<HendelserService>(relaxed = true),
+    )
+}


### PR DESCRIPTION
## Beskrivelse

Fikser shutdown-timeout ved deploy der gammel pod kan logge `Failed to destroy application instance` fordi Kafka-consumeren står blokkert i `poll(Duration.ofSeconds(10))` mens Ktor bare venter 5000 ms på application destroy.

Løsningen bruker Kafka-klientens trådsikre `wakeup()` ved `ApplicationStopping`, håndterer `WakeupException` som kontrollert shutdown og lukker consumeren med bounded `close(Duration.ofSeconds(3))` fra consumer-coroutinen.

## Endringer

- `CommonKafkaService.kt`: legger til `kafkaWakeup()`, skiller `WakeupException` og `CancellationException` fra reelle Kafka-feil, og lukker consumer med `close(Duration.ofSeconds(3))` i `finally`.
- `KafkaConsumers.kt`: kaller `commonKafkaService.kafkaWakeup()` før consumer-jobben kanselleres ved `ApplicationStopping`.
- `CommonKafkaServiceTest.kt`: legger til tester for wakeup-shutdown, bounded close, close-feil, cancellation propagation, retry-path og wakeup-delegering.

## Issue

Closes #689

## Verifisering

- `./gradlew test --tests no.nav.syfo.common.kafka.CommonKafkaServiceTest`
- `./gradlew build`

## Inspeksjon

R4-inspeksjon kjørt med `inspektor-claude` og `inspektor-gpt`: ingen blokkere eller warnings i koden.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
